### PR TITLE
Fix renderer resize so 3D scene renders in Chrome

### DIFF
--- a/src/systems/renderer3d.js
+++ b/src/systems/renderer3d.js
@@ -14,6 +14,8 @@ export class Renderer3D {
 
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
     this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.domElement.style.width = '100%';
+    this.renderer.domElement.style.height = '100%';
     this.container.appendChild(this.renderer.domElement);
 
     this.tileGroup = new THREE.Group();
@@ -25,6 +27,10 @@ export class Renderer3D {
     this.setupLights();
     this.handleResize();
     window.addEventListener('resize', () => this.handleResize());
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.handleResize());
+      this.resizeObserver.observe(this.container);
+    }
   }
 
   setupLights() {
@@ -131,9 +137,11 @@ export class Renderer3D {
 
   handleResize() {
     if (!this.container || !this.renderer) return;
-    const { clientWidth, clientHeight } = this.container;
-    this.renderer.setSize(clientWidth, clientHeight);
-    this.camera.aspect = clientWidth / clientHeight;
+    const bounds = this.container.getBoundingClientRect();
+    const width = Math.max(1, Math.floor(bounds.width));
+    const height = Math.max(1, Math.floor(bounds.height));
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
   }
 }


### PR DESCRIPTION
## Summary
- ensure the Three.js renderer canvas tracks its container size using ResizeObserver
- guard against zero-sized bounds so the camera aspect ratio remains valid
- force the renderer canvas element to fill the container for consistent sizing

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db87026ccc8331b8ca78c1ea613fc1