### PR TITLE
Replace renderer with standalone WebGL implementation

### DIFF
--- a/src/systems/renderer3d.js
+++ b/src/systems/renderer3d.js
@@ -1,30 +1,54 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.155/build/three.module.js';
-
 const TILE_SIZE = 4;
-
 export class Renderer3D {
   constructor(container) {
     this.container = container;
-    this.scene = new THREE.Scene();
-    this.scene.background = new THREE.Color(0x080506);
+    this.canvas = document.createElement('canvas');
+    this.canvas.className = 'renderer-canvas';
+    this.container.appendChild(this.canvas);
 
-    this.camera = new THREE.PerspectiveCamera(55, 1, 0.1, 1000);
-    this.camera.position.set(10, 24, 24);
-    this.camera.lookAt(new THREE.Vector3(0, 0, 0));
+    this.gl = this.canvas.getContext('webgl', { antialias: true, alpha: false });
+    if (!this.gl) {
+      this.showFallbackMessage();
+      return;
+    }
 
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
-    this.renderer.setPixelRatio(window.devicePixelRatio);
-    this.renderer.domElement.style.width = '100%';
-    this.renderer.domElement.style.height = '100%';
-    this.container.appendChild(this.renderer.domElement);
+    this.program = createProgram(this.gl, vertexShaderSource, fragmentShaderSource);
+    if (!this.program) {
+      this.container.removeChild(this.canvas);
+      this.showFallbackMessage();
+      this.gl = null;
+      return;
+    }
+    this.attribLocations = {
+      position: this.gl.getAttribLocation(this.program, 'position'),
+      color: this.gl.getAttribLocation(this.program, 'color')
+    };
+    this.uniformLocations = {
+      projectionView: this.gl.getUniformLocation(this.program, 'uProjectionView'),
+      offset: this.gl.getUniformLocation(this.program, 'uOffset')
+    };
 
-    this.tileGroup = new THREE.Group();
-    this.scene.add(this.tileGroup);
+    this.positionBuffer = this.gl.createBuffer();
+    this.colorBuffer = this.gl.createBuffer();
 
-    this.partyMarker = null;
-    this.clock = new THREE.Clock();
+    this.tiles = [];
+    this.tileColorArray = null;
+    this.tileVertexCount = 0;
+    this.markerInstances = [];
+    this.lastMap = null;
 
-    this.setupLights();
+    this.partyMarker = this.createPartyMarker();
+    this.partyOffset = { x: 0, y: 0.8, z: 0 };
+    this.highlightKey = null;
+
+    this.cameraOffset = { x: 14, y: 20, z: 22 };
+
+    this.projectionMatrix = createPerspectiveMatrix((55 * Math.PI) / 180, 1, 0.1, 1000);
+    this.elapsed = 0;
+
+    this.gl.enable(this.gl.DEPTH_TEST);
+    this.gl.clearColor(0.04, 0.03, 0.07, 1);
+
     this.handleResize();
     window.addEventListener('resize', () => this.handleResize());
     if (typeof ResizeObserver !== 'undefined') {
@@ -33,115 +57,483 @@ export class Renderer3D {
     }
   }
 
-  setupLights() {
-    const ambient = new THREE.AmbientLight(0x777777);
-    this.scene.add(ambient);
-
-    const dirLight = new THREE.DirectionalLight(0xfff0d1, 0.8);
-    dirLight.position.set(20, 30, 20);
-    this.scene.add(dirLight);
-
-    const backLight = new THREE.DirectionalLight(0x4060ff, 0.4);
-    backLight.position.set(-25, 20, -15);
-    this.scene.add(backLight);
+  showFallbackMessage() {
+    const message = document.createElement('div');
+    message.textContent =
+      'WebGL wird von diesem Browser oder Kontext nicht unterstützt. Die Karte kann nicht angezeigt werden.';
+    message.style.padding = '1rem';
+    message.style.textAlign = 'center';
+    message.style.color = '#f0e6d2';
+    this.container.appendChild(message);
   }
 
   buildWorld(map, terrainTypes) {
-    while (this.tileGroup.children.length) {
-      this.tileGroup.remove(this.tileGroup.children[0]);
-    }
+    if (!this.gl) return;
 
-    const geometry = new THREE.PlaneGeometry(TILE_SIZE, TILE_SIZE);
-    geometry.rotateX(-Math.PI / 2);
+    this.tiles = [];
+    this.markerInstances = [];
+
+    const positions = [];
+    const colors = [];
 
     map.layout.forEach((row, y) => {
       row.forEach((tileKey, x) => {
-        const data = terrainTypes[tileKey];
-        const material = new THREE.MeshLambertMaterial({ color: data.color, emissive: 0x000000 });
-        const mesh = new THREE.Mesh(geometry.clone(), material);
-        mesh.position.set((x - map.width / 2) * TILE_SIZE, 0, (y - map.height / 2) * TILE_SIZE);
-        mesh.userData = { tileKey, highlight: false };
-        this.tileGroup.add(mesh);
+        const centerX = (x - map.width / 2) * TILE_SIZE;
+        const centerZ = (y - map.height / 2) * TILE_SIZE;
+        const half = TILE_SIZE / 2;
+        const baseColor = hexToRgb(terrainTypes[tileKey].color);
+
+        const corners = [
+          [centerX - half, 0, centerZ - half],
+          [centerX + half, 0, centerZ - half],
+          [centerX + half, 0, centerZ + half],
+          [centerX - half, 0, centerZ + half]
+        ];
+        const triangleOrder = [0, 1, 2, 0, 2, 3];
+        const colorStart = colors.length;
+
+        triangleOrder.forEach((index) => {
+          const vertex = corners[index];
+          positions.push(vertex[0], vertex[1], vertex[2]);
+          colors.push(baseColor[0], baseColor[1], baseColor[2]);
+        });
+
+        const tile = {
+          x,
+          y,
+          baseColor,
+          colorOffset: colorStart,
+          vertexCount: triangleOrder.length
+        };
+        this.tiles.push(tile);
 
         if (tileKey === 'town') {
-          this.addTownMarker(mesh.position.clone());
+          this.addMarker(createBoxGeometry(1.4, 2.5, 1.4, hexToRgb(0xc4a484)), {
+            x: centerX,
+            y: 0,
+            z: centerZ
+          });
         }
         if (tileKey === 'ruin') {
-          this.addRuinMarker(mesh.position.clone());
+          this.addMarker(createBoxGeometry(1.8, 1.8, 1.8, hexToRgb(0x666688)), {
+            x: centerX,
+            y: 0,
+            z: centerZ
+          });
         }
       });
     });
 
-    if (!this.partyMarker) {
-      const cone = new THREE.ConeGeometry(TILE_SIZE * 0.3, TILE_SIZE * 0.8, 16);
-      const material = new THREE.MeshStandardMaterial({ color: 0xffe066, emissive: 0x222200 });
-      this.partyMarker = new THREE.Mesh(cone, material);
-      this.partyMarker.rotation.x = Math.PI;
-      this.scene.add(this.partyMarker);
-    }
+    this.tileVertexCount = positions.length / 3;
+    this.tileColorArray = new Float32Array(colors);
+
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.positionBuffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(positions), this.gl.STATIC_DRAW);
+
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.colorBuffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, this.tileColorArray, this.gl.DYNAMIC_DRAW);
+
+    this.highlightKey = null;
+    this.lastMap = map;
   }
 
-  addTownMarker(position) {
-    const geometry = new THREE.CylinderGeometry(0.7, 0.7, 2.2, 12);
-    const material = new THREE.MeshStandardMaterial({ color: 0xc4a484, metalness: 0.1, roughness: 0.6 });
-    const tower = new THREE.Mesh(geometry, material);
-    tower.position.copy(position);
-    tower.position.y = 1.1;
-    this.scene.add(tower);
-  }
+  addMarker(geometry, offset) {
+    const gl = this.gl;
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, geometry.positions, gl.STATIC_DRAW);
 
-  addRuinMarker(position) {
-    const geometry = new THREE.BoxGeometry(1.8, 1.8, 1.8);
-    const material = new THREE.MeshStandardMaterial({ color: 0x666688, roughness: 0.9 });
-    const ruin = new THREE.Mesh(geometry, material);
-    ruin.position.copy(position);
-    ruin.position.y = 0.9;
-    this.scene.add(ruin);
-  }
+    const colorBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, geometry.colors, gl.STATIC_DRAW);
 
-  updatePartyPosition(position, map) {
-    if (!this.partyMarker) return;
-    const x = (position.x - map.width / 2) * TILE_SIZE;
-    const z = (position.y - map.height / 2) * TILE_SIZE;
-    this.partyMarker.position.set(x, TILE_SIZE * 0.4, z);
-  }
-
-  highlightTile(position, map) {
-    const targetX = (position.x - map.width / 2) * TILE_SIZE;
-    const targetZ = (position.y - map.height / 2) * TILE_SIZE;
-    this.tileGroup.children.forEach((tile) => {
-      const isTarget = Math.abs(tile.position.x - targetX) < 0.01 && Math.abs(tile.position.z - targetZ) < 0.01;
-      if (tile.material.emissive) {
-        tile.material.emissive.setHex(isTarget ? 0x222244 : 0x000000);
-      }
+    this.markerInstances.push({
+      positionBuffer,
+      colorBuffer,
+      vertexCount: geometry.vertexCount,
+      offset
     });
   }
 
-  update() {
-    if (this.partyMarker) {
-      const elapsed = this.clock.getElapsedTime();
-      const bounce = Math.sin(elapsed * 3) * 0.1;
-      this.partyMarker.position.y = TILE_SIZE * 0.4 + bounce;
+  createPartyMarker() {
+    if (!this.gl) return null;
+    const markerHeight = TILE_SIZE * 0.9;
+    const base = TILE_SIZE * 0.35;
+    const positions = [
+      0, markerHeight, 0,
+      -base, 0, -base,
+      base, 0, -base,
+      0, markerHeight, 0,
+      base, 0, -base,
+      base, 0, base,
+      0, markerHeight, 0,
+      base, 0, base,
+      -base, 0, base,
+      0, markerHeight, 0,
+      -base, 0, base,
+      -base, 0, -base
+    ];
+    const color = hexToRgb(0xffe066);
+    const colors = new Array((positions.length / 3) * 3).fill(0);
+    for (let i = 0; i < colors.length; i += 3) {
+      colors[i] = color[0];
+      colors[i + 1] = color[1];
+      colors[i + 2] = color[2];
     }
-    this.renderer.render(this.scene, this.camera);
+
+    const gl = this.gl;
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+    const colorBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
+
+    return {
+      positionBuffer,
+      colorBuffer,
+      vertexCount: positions.length / 3
+    };
+  }
+
+  updatePartyPosition(position, map) {
+    if (!this.gl) return;
+    const x = (position.x - map.width / 2) * TILE_SIZE;
+    const z = (position.y - map.height / 2) * TILE_SIZE;
+    this.partyOffset.x = x;
+    this.partyOffset.z = z;
+  }
+
+  highlightTile(position, map) {
+    if (!this.gl || !this.tileColorArray) return;
+    const key = `${position.x},${position.y}`;
+    if (this.highlightKey === key && this.lastMap === map) return;
+
+    this.tiles.forEach((tile) => {
+      const isTarget = tile.x === position.x && tile.y === position.y;
+      const color = isTarget ? brightenColor(tile.baseColor) : tile.baseColor;
+      for (let i = 0; i < tile.vertexCount; i++) {
+        const offset = tile.colorOffset + i * 3;
+        this.tileColorArray[offset] = color[0];
+        this.tileColorArray[offset + 1] = color[1];
+        this.tileColorArray[offset + 2] = color[2];
+      }
+    });
+
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.colorBuffer);
+    this.gl.bufferSubData(this.gl.ARRAY_BUFFER, 0, this.tileColorArray);
+    this.highlightKey = key;
+    this.lastMap = map;
+  }
+
+  update() {
+    if (!this.gl) return;
+    const now = performance.now();
+    if (!this.lastFrameTime) {
+      this.lastFrameTime = now;
+    }
+    const delta = (now - this.lastFrameTime) / 1000;
+    this.lastFrameTime = now;
+    this.elapsed += delta;
+
+    const bounce = Math.sin(this.elapsed * 3) * 0.25;
+    const partyY = TILE_SIZE * 0.45 + bounce;
+
+    const target = [this.partyOffset.x, 0, this.partyOffset.z];
+    const cameraPosition = [
+      target[0] + this.cameraOffset.x,
+      target[1] + this.cameraOffset.y,
+      target[2] + this.cameraOffset.z
+    ];
+    const viewMatrix = createLookAtMatrix(cameraPosition, target, [0, 1, 0]);
+    const projectionView = multiplyMatrices(this.projectionMatrix, viewMatrix);
+
+    const gl = this.gl;
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(this.program);
+    gl.uniformMatrix4fv(this.uniformLocations.projectionView, false, projectionView);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.positionBuffer);
+    gl.enableVertexAttribArray(this.attribLocations.position);
+    gl.vertexAttribPointer(this.attribLocations.position, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.colorBuffer);
+    gl.enableVertexAttribArray(this.attribLocations.color);
+    gl.vertexAttribPointer(this.attribLocations.color, 3, gl.FLOAT, false, 0, 0);
+
+    gl.uniform3f(this.uniformLocations.offset, 0, 0, 0);
+    gl.drawArrays(gl.TRIANGLES, 0, this.tileVertexCount);
+
+    this.markerInstances.forEach((marker) => {
+      gl.bindBuffer(gl.ARRAY_BUFFER, marker.positionBuffer);
+      gl.vertexAttribPointer(this.attribLocations.position, 3, gl.FLOAT, false, 0, 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, marker.colorBuffer);
+      gl.vertexAttribPointer(this.attribLocations.color, 3, gl.FLOAT, false, 0, 0);
+      gl.uniform3f(this.uniformLocations.offset, marker.offset.x, marker.offset.y, marker.offset.z);
+      gl.drawArrays(gl.TRIANGLES, 0, marker.vertexCount);
+    });
+
+    if (this.partyMarker) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.partyMarker.positionBuffer);
+      gl.vertexAttribPointer(this.attribLocations.position, 3, gl.FLOAT, false, 0, 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.partyMarker.colorBuffer);
+      gl.vertexAttribPointer(this.attribLocations.color, 3, gl.FLOAT, false, 0, 0);
+      gl.uniform3f(this.uniformLocations.offset, this.partyOffset.x, partyY, this.partyOffset.z);
+      gl.drawArrays(gl.TRIANGLES, 0, this.partyMarker.vertexCount);
+    }
   }
 
   start() {
+    if (!this.gl) return;
     const animate = () => {
-      requestAnimationFrame(animate);
-      this.clock.getDelta();
       this.update();
+      this.frameHandle = requestAnimationFrame(animate);
     };
     animate();
   }
 
   handleResize() {
-    if (!this.container || !this.renderer) return;
+    if (!this.gl) return;
     const bounds = this.container.getBoundingClientRect();
     const width = Math.max(1, Math.floor(bounds.width));
     const height = Math.max(1, Math.floor(bounds.height));
-    this.renderer.setSize(width, height, false);
-    this.camera.aspect = width / height;
-    this.camera.updateProjectionMatrix();
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    this.canvas.width = width * dpr;
+    this.canvas.height = height * dpr;
+    this.canvas.style.width = `${width}px`;
+    this.canvas.style.height = `${height}px`;
+
+    this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    const aspect = width / height;
+    this.projectionMatrix = createPerspectiveMatrix((55 * Math.PI) / 180, aspect, 0.1, 1000);
   }
+}
+
+const vertexShaderSource = `
+attribute vec3 position;
+attribute vec3 color;
+uniform mat4 uProjectionView;
+uniform vec3 uOffset;
+varying vec3 vColor;
+void main() {
+  vec3 worldPosition = position + uOffset;
+  gl_Position = uProjectionView * vec4(worldPosition, 1.0);
+  vColor = color;
+}
+`;
+
+const fragmentShaderSource = `
+precision mediump float;
+varying vec3 vColor;
+void main() {
+  gl_FragColor = vec4(vColor, 1.0);
+}
+`;
+
+function createProgram(gl, vertexSource, fragmentSource) {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource);
+  const program = gl.createProgram();
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    console.error('WebGL program failed to link', gl.getProgramInfoLog(program));
+    gl.deleteProgram(program);
+    return null;
+  }
+  return program;
+}
+
+function compileShader(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    console.error('WebGL shader compile error', gl.getShaderInfoLog(shader));
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function hexToRgb(hex) {
+  const value = typeof hex === 'number' ? hex : parseInt(hex.replace('#', ''), 16);
+  const r = ((value >> 16) & 0xff) / 255;
+  const g = ((value >> 8) & 0xff) / 255;
+  const b = (value & 0xff) / 255;
+  return [r, g, b];
+}
+
+function createPerspectiveMatrix(fov, aspect, near, far) {
+  const f = 1.0 / Math.tan(fov / 2);
+  const nf = 1 / (near - far);
+  const out = new Float32Array(16);
+  out[0] = f / aspect;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+
+  out[4] = 0;
+  out[5] = f;
+  out[6] = 0;
+  out[7] = 0;
+
+  out[8] = 0;
+  out[9] = 0;
+  out[10] = (far + near) * nf;
+  out[11] = -1;
+
+  out[12] = 0;
+  out[13] = 0;
+  out[14] = 2 * far * near * nf;
+  out[15] = 0;
+  return out;
+}
+
+function createLookAtMatrix(eye, center, up) {
+  const [ex, ey, ez] = eye;
+  const [cx, cy, cz] = center;
+  const [ux, uy, uz] = up;
+
+  let zx = ex - cx;
+  let zy = ey - cy;
+  let zz = ez - cz;
+  let len = Math.hypot(zx, zy, zz);
+  if (len === 0) {
+    zz = 1;
+  } else {
+    zx /= len;
+    zy /= len;
+    zz /= len;
+  }
+
+  let xx = uy * zz - uz * zy;
+  let xy = uz * zx - ux * zz;
+  let xz = ux * zy - uy * zx;
+  len = Math.hypot(xx, xy, xz);
+  if (len === 0) {
+    xx = 0;
+    xy = 0;
+    xz = 0;
+  } else {
+    xx /= len;
+    xy /= len;
+    xz /= len;
+  }
+
+  let yx = zy * xz - zz * xy;
+  let yy = zz * xx - zx * xz;
+  let yz = zx * xy - zy * xx;
+  len = Math.hypot(yx, yy, yz);
+  if (len === 0) {
+    yx = 0;
+    yy = 0;
+    yz = 0;
+  } else {
+    yx /= len;
+    yy /= len;
+    yz /= len;
+  }
+
+  const out = new Float32Array(16);
+  out[0] = xx;
+  out[1] = yx;
+  out[2] = zx;
+  out[3] = 0;
+  out[4] = xy;
+  out[5] = yy;
+  out[6] = zy;
+  out[7] = 0;
+  out[8] = xz;
+  out[9] = yz;
+  out[10] = zz;
+  out[11] = 0;
+  out[12] = -(xx * ex + xy * ey + xz * ez);
+  out[13] = -(yx * ex + yy * ey + yz * ez);
+  out[14] = -(zx * ex + zy * ey + zz * ez);
+  out[15] = 1;
+  return out;
+}
+
+function multiplyMatrices(a, b) {
+  const out = new Float32Array(16);
+  for (let i = 0; i < 4; i++) {
+    for (let j = 0; j < 4; j++) {
+      out[i * 4 + j] =
+        a[i * 4 + 0] * b[0 * 4 + j] +
+        a[i * 4 + 1] * b[1 * 4 + j] +
+        a[i * 4 + 2] * b[2 * 4 + j] +
+        a[i * 4 + 3] * b[3 * 4 + j];
+    }
+  }
+  return out;
+}
+
+function createBoxGeometry(width, height, depth, color) {
+  const w = width / 2;
+  const h = height;
+  const d = depth / 2;
+  const positions = new Float32Array([
+    -w, 0, d,
+    w, 0, d,
+    w, h, d,
+    -w, 0, d,
+    w, h, d,
+    -w, h, d,
+
+    -w, 0, -d,
+    -w, h, -d,
+    w, h, -d,
+    -w, 0, -d,
+    w, h, -d,
+    w, 0, -d,
+
+    -w, 0, -d,
+    -w, 0, d,
+    -w, h, d,
+    -w, 0, -d,
+    -w, h, d,
+    -w, h, -d,
+
+    w, 0, -d,
+    w, h, -d,
+    w, h, d,
+    w, 0, -d,
+    w, h, d,
+    w, 0, d,
+
+    -w, h, -d,
+    -w, h, d,
+    w, h, d,
+    -w, h, -d,
+    w, h, d,
+    w, h, -d,
+
+    -w, 0, -d,
+    w, 0, -d,
+    w, 0, d,
+    -w, 0, -d,
+    w, 0, d,
+    -w, 0, d
+  ]);
+
+  const colors = new Float32Array((positions.length / 3) * 3);
+  for (let i = 0; i < colors.length; i += 3) {
+    colors[i] = color[0];
+    colors[i + 1] = color[1];
+    colors[i + 2] = color[2];
+  }
+  return { positions, colors, vertexCount: positions.length / 3 };
+}
+
+function brightenColor(color, amount = 0.25) {
+  return [
+    Math.min(color[0] + amount, 1),
+    Math.min(color[1] + amount, 1),
+    Math.min(color[2] + amount, 1)
+  ];
 }


### PR DESCRIPTION
## Summary
- replace the Three.js-based renderer with a standalone WebGL pipeline so the map loads when opened from local files
- generate tile geometry, party marker, and point-of-interest columns directly in WebGL with custom shaders
- add highlight, camera-follow, and WebGL fallback handling without relying on external CDNs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db89d3a4a48331a7e7b45d3489ae18